### PR TITLE
Fix ModelStatusController paths

### DIFF
--- a/src/Controllers/ModelStatusController.php
+++ b/src/Controllers/ModelStatusController.php
@@ -1,9 +1,9 @@
 <?php
-require __DIR__ . '/../vendor/autoload.php';
+require __DIR__ . '/../../vendor/autoload.php';
 
 use GuzzleHttp\Client;
 
-$config = require __DIR__ . '/../src/config.php';
+$config = require __DIR__ . '/../config.php';
 
 $ollamaApiUrl = $config['ollamaApiUrl'];
 $jwtToken = $config['jwtToken'];


### PR DESCRIPTION
## Summary
- fix paths to autoload and config in ModelStatusController

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840ce37e77883269976b4ffc8ba795d