### PR TITLE
Update ModelStatusController paths

### DIFF
--- a/src/Controllers/ModelStatusController.php
+++ b/src/Controllers/ModelStatusController.php
@@ -3,7 +3,7 @@ require __DIR__ . '/../../vendor/autoload.php';
 
 use GuzzleHttp\Client;
 
-require __DIR__ . '/../config.php';
+$config = require __DIR__ . '/../config.php';
 
 $ollamaApiUrl = $config['ollamaApiUrl'];
 $jwtToken = $config['jwtToken'];

--- a/src/Controllers/ModelStatusController.php
+++ b/src/Controllers/ModelStatusController.php
@@ -1,9 +1,9 @@
 <?php
-require __DIR__ . '/../vendor/autoload.php';
+require __DIR__ . '/../../vendor/autoload.php';
 
 use GuzzleHttp\Client;
 
-$config = require __DIR__ . '/../src/config.php';
+require __DIR__ . '/../config.php';
 
 $ollamaApiUrl = $config['ollamaApiUrl'];
 $jwtToken = $config['jwtToken'];


### PR DESCRIPTION
## Summary
- fix autoload path in `ModelStatusController`
- use root config in `ModelStatusController`

## Testing
- `php -l src/Controllers/ModelStatusController.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6840cf89e4208326be416697871676c5