### PR TITLE
🎨 Palette: Improve drag and drop upload zone accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Drag and Drop Upload Zone Keyboard Accessibility
+**Learning:** Custom drag-and-drop file upload zones implemented as `<div>` elements with `onclick` handlers completely lack keyboard accessibility by default. Screen readers ignore them, and keyboard users cannot trigger them or tab to them.
+**Action:** Always ensure custom upload zones or clickable `<div>` elements get `role="button"`, `tabindex="0"`, an explicit `aria-label`, and `onkeydown` handlers that listen for 'Enter' or ' ' (Space) keys to programmatically trigger the underlying `<input type="file">`. Remember to also add `:focus-visible` styles to these elements so keyboard users know they are focused.

--- a/public/assets/css/modern.css
+++ b/public/assets/css/modern.css
@@ -338,7 +338,9 @@ button:focus-visible,
 .btn-icon:focus-visible,
 a:focus-visible,
 textarea:focus-visible,
-input:focus-visible {
+input:focus-visible,
+.upload-zone:focus-visible,
+#upload-zone:focus-visible {
     outline: 2px solid var(--accent);
     outline-offset: 2px;
     border-radius: 4px;

--- a/public/documents.php
+++ b/public/documents.php
@@ -71,7 +71,7 @@ $companyUrl = $config['companyUrl'] ?? '{{COMPANY_URL}}';
         </div>
 
         <!-- Upload Zone (Collapsible) -->
-        <div class="glass-card" id="upload-zone" style="margin-bottom: 24px; padding: 32px; text-align: center; cursor: pointer; border: 2px dashed var(--glass-border); transition: all 0.3s;" onclick="document.getElementById('file-input').click()">
+        <div class="glass-card" id="upload-zone" style="margin-bottom: 24px; padding: 32px; text-align: center; cursor: pointer; border: 2px dashed var(--glass-border); transition: all 0.3s;" onclick="document.getElementById('file-input').click()" role="button" tabindex="0" aria-label="Upload document" onkeydown="if(event.key==='Enter'||event.key===' ') { event.preventDefault(); document.getElementById('file-input').click(); }">
             <?php echo IconHelper::icon(IconHelper::getActionIcon('upload'), '', 'font-size: 48px; color: var(--accent);'); ?>
             <p style="margin-top: 16px; font-weight: 600; color: var(--text-primary);">Drag & drop files here</p>
             <p style="margin-top: 8px; color: var(--text-secondary); font-size: 14px;">

--- a/public/index.php
+++ b/public/index.php
@@ -74,7 +74,7 @@ $companyUrl = $config['companyUrl'] ?? '{{COMPANY_URL}}';
         </div>
         
         <div class="documents-panel">
-            <div class="upload-zone" id="upload-zone">
+            <div class="upload-zone" id="upload-zone" role="button" tabindex="0" aria-label="Upload document" onkeydown="if(event.key==='Enter'||event.key===' ') { event.preventDefault(); document.getElementById('file-input').click(); }">
                 <?php echo IconHelper::icon(IconHelper::getActionIcon('upload'), '', 'font-size: 48px; color: var(--accent);'); ?>
                 <p style="margin-top: 16px; font-weight: 600;">Drag & drop files here</p>
                 <p style="margin-top: 8px; color: var(--text-secondary); font-size: 14px;">


### PR DESCRIPTION
💡 **What:** 
- Added `role="button"`, `tabindex="0"`, and `aria-label="Upload document"` to the drag-and-drop upload zones in `public/index.php` and `public/documents.php`.
- Added an `onkeydown` handler to allow keyboard users to trigger the hidden file input by pressing the `Enter` or `Space` keys.
- Added `:focus-visible` styles to these `.upload-zone` elements in `public/assets/css/modern.css` to provide clear visual feedback during keyboard navigation.
- Created `.jules/palette.md` to document this critical learning for future reference.

🎯 **Why:** The file upload zones were acting as clickable buttons but lacked the necessary attributes for screen readers and keyboard navigation, breaking accessibility for a core task (document upload).

♿ **Accessibility:** This ensures the primary document upload function is fully accessible via keyboard and properly announced by screen readers as a button.

---
*PR created automatically by Jules for task [10793576380974267990](https://jules.google.com/task/10793576380974267990) started by @LebToki*