### PR TITLE
🎨 Palette: Add helpful call-to-action to documents empty state

### DIFF
--- a/public/documents.php
+++ b/public/documents.php
@@ -120,8 +120,12 @@ $companyUrl = $config['companyUrl'] ?? '{{COMPANY_URL}}';
                 </tbody>
             </table>
             </div>
-            <div id="table-empty" style="display: none; text-align: center; padding: 40px; color: var(--text-secondary);">
-                <p>No documents found</p>
+            <div id="table-empty" style="display: none; text-align: center; padding: 60px 40px; color: var(--text-secondary);">
+                <?php echo IconHelper::icon('mdi:file-document-outline', '', 'font-size: 48px; color: var(--text-secondary); opacity: 0.5; margin-bottom: 16px;'); ?>
+                <p style="font-size: 16px; margin-bottom: 24px;">No documents found</p>
+                <button class="btn-modern secondary" onclick="document.getElementById('file-input').click()" aria-label="Upload your first document" role="button">
+                    <?php echo IconHelper::icon(IconHelper::getActionIcon('upload')); ?> Upload First Document
+                </button>
             </div>
         </div>
 


### PR DESCRIPTION
💡 What: Added a clear call-to-action button and icon to the empty state of the document list.
🎯 Why: It improves the onboarding experience when a user hasn't uploaded any documents, providing a one-click way to start the process instead of just saying "No documents found".
📸 Before/After: Visual changes verified via Playwright screenshot.
♿ Accessibility: The new upload button is keyboard accessible (it triggers the file input) and includes a descriptive `aria-label`.

---
*PR created automatically by Jules for task [15095151742921907622](https://jules.google.com/task/15095151742921907622) started by @LebToki*