### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Path Traversal in document upload

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** The `$model` parameter in `ModelStatusController.php` was taken directly from user input (`$_GET['model']`) and appended to an API URL without validation or sanitization, potentially allowing an attacker to inject path traversal characters (like `../`) and hit unintended endpoints via Server-Side Request Forgery.
 **Learning:** Even when hitting internal or trusted upstream APIs (like Ollama), user input appended to the path or body must be strictly validated. Guzzle handles requests reliably, but does not sanitize path inputs by default.
 **Prevention:** Always validate parameters against an expected allowlist or strict format regex (e.g., `^[a-zA-Z0-9\-_:\.]+$` for model names) before using them to construct upstream requests.
+
+## 2024-05-25 - Path Traversal in Document Upload
+**Vulnerability:** In `public/api/documents.php`, the file name was directly extracted using `$originalName = $_FILES['document']['name']` and subsequently used in the destination path for `move_uploaded_file()`. If an attacker uploaded a file named `../../shell.php`, the file would be saved outside the intended `uploads/` directory, causing a critical path traversal and arbitrary file upload vulnerability.
+**Learning:** `$_FILES['input_name']['name']` is entirely client-controlled and must never be trusted. When using it to construct file paths, it can lead to path traversal vulnerabilities if it contains `../` sequences.
+**Prevention:** Always sanitize the filename from `$_FILES` using `basename()` to strip any directory paths and ensure only the final filename is used.

--- a/public/api/documents.php
+++ b/public/api/documents.php
@@ -21,7 +21,8 @@ if (RequestHelper::isMethod('POST')) {
             }
             
             $file = $_FILES['document'];
-            $originalName = $file['name'];
+            // Security Fix: Prevent path traversal in file uploads
+            $originalName = basename($file['name']);
             $tempPath = $file['tmp_name'];
             
             // Validate file
@@ -69,7 +70,8 @@ if (RequestHelper::isMethod('POST')) {
             }
             
             $file = $_FILES['document'];
-            $originalName = $file['name'];
+            // Security Fix: Prevent path traversal
+            $originalName = basename($file['name']);
             $tempPath = $file['tmp_name'];
             
             $validation = $documentService->validateFile($tempPath, $originalName);
@@ -83,7 +85,8 @@ if (RequestHelper::isMethod('POST')) {
             }
             
             $file = $_FILES['document'];
-            $originalName = $file['name'];
+            // Security Fix: Prevent path traversal
+            $originalName = basename($file['name']);
             $tempPath = $file['tmp_name'];
             
             $validation = $documentService->validateFile($tempPath, $originalName);


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: `public/api/documents.php` uses `$_FILES['document']['name']` to construct the target file path without validating or sanitizing the input. This allowed an attacker to inject `../` to upload files to arbitrary locations.
🎯 Impact: Arbitrary file upload vulnerability via path traversal. An attacker could overwrite files or upload a web shell outside of the `data/uploads/` directory to gain RCE on the server.
🔧 Fix: Wrapped the user-supplied filename in `basename()` before using it for validation and file operations.
✅ Verification: Ran `php -l` and tested the RAG system integrations to confirm functionality wasn't broken by the filename change.

Also added a journal entry in `.jules/sentinel.md` documenting this finding.

---
*PR created automatically by Jules for task [8272409997752845854](https://jules.google.com/task/8272409997752845854) started by @LebToki*