### PR TITLE
🎨 Palette: Add ARIA labels to icon-only buttons for accessibility

### DIFF
--- a/public/assets/js/enhanced-chat.js
+++ b/public/assets/js/enhanced-chat.js
@@ -310,6 +310,7 @@ function addMessageActions(messageElement, messageId, content, role) {
     const copyBtn = document.createElement('button');
     copyBtn.className = 'message-action-btn';
     copyBtn.title = 'Copy message';
+    copyBtn.setAttribute('aria-label', 'Copy message');
     copyBtn.innerHTML = IconHelper.icon('mdi:content-copy');
     copyBtn.onclick = function() {
         copyToClipboard(content, copyBtn);
@@ -320,6 +321,7 @@ function addMessageActions(messageElement, messageId, content, role) {
         const editBtn = document.createElement('button');
         editBtn.className = 'message-action-btn';
         editBtn.title = 'Edit message';
+        editBtn.setAttribute('aria-label', 'Edit message');
         editBtn.innerHTML = IconHelper.icon('mdi:pencil');
         editBtn.onclick = function() {
             editMessage(messageElement, messageId, content);
@@ -332,6 +334,7 @@ function addMessageActions(messageElement, messageId, content, role) {
         const regenerateBtn = document.createElement('button');
         regenerateBtn.className = 'message-action-btn';
         regenerateBtn.title = 'Regenerate response';
+        regenerateBtn.setAttribute('aria-label', 'Regenerate response');
         regenerateBtn.innerHTML = IconHelper.icon('mdi:refresh');
         regenerateBtn.onclick = function() {
             regenerateMessage(messageId);
@@ -476,7 +479,7 @@ function addCodeBlockCopyButton(codeBlock) {
     
     header.innerHTML = `
         <span class="code-block-language">${language}</span>
-        <button class="code-block-copy" title="Copy code">
+        <button class="code-block-copy" title="Copy code" aria-label="Copy code block">
             ${IconHelper.icon('mdi:content-copy')}
         </button>
     `;
@@ -502,8 +505,8 @@ function initializeSearch() {
     searchBar.className = 'search-bar';
     searchBar.innerHTML = `
         <iconify-icon icon="mdi:magnify" class="search-icon"></iconify-icon>
-        <input type="text" id="chat-search" class="search-input" placeholder="Search chats...">
-        <button class="search-clear" onclick="clearSearch()">
+        <input type="text" id="chat-search" class="search-input" placeholder="Search chats..." aria-label="Search chat sessions">
+        <button class="search-clear" onclick="clearSearch()" aria-label="Clear search">
             ${IconHelper.icon('mdi:close')}
         </button>
     `;
@@ -552,6 +555,7 @@ function initializeExport() {
     const exportBtn = document.createElement('button');
     exportBtn.className = 'btn-icon';
     exportBtn.title = 'Export chat';
+    exportBtn.setAttribute('aria-label', 'Export chat session');
     exportBtn.innerHTML = IconHelper.icon('mdi:download');
     exportBtn.onclick = function(e) {
         e.stopPropagation();
@@ -717,7 +721,7 @@ function showEnhancedNotification(message, type = 'info', duration = 4000) {
             <div class="notification-title">${titles[type] || titles.info}</div>
             <div class="notification-message">${message}</div>
         </div>
-        <button class="notification-close" onclick="this.parentElement.remove()">
+        <button class="notification-close" onclick="this.parentElement.remove()" aria-label="Close notification">
             ${IconHelper.icon('mdi:close')}
         </button>
     `;

--- a/public/assets/js/modern-chat.js
+++ b/public/assets/js/modern-chat.js
@@ -353,7 +353,7 @@ function updateFilePreview() {
                 <span style="font-size: 14px;">${
                 file.name
             }</span>
-                <button onclick="removeFile(${ index })" style="background: none; border: none; color: var(--danger); margin-left: 8px; cursor: pointer;">
+                <button onclick="removeFile(${ index })" style="background: none; border: none; color: var(--danger); margin-left: 8px; cursor: pointer;" aria-label="Remove attached file">
                     ${
                 IconHelper.icon( IconHelper.getActionIcon( 'close' ) )
             }
@@ -1078,7 +1078,7 @@ function renderDocuments( documents ) {
         }
             <button class="btn-icon" onclick="deleteDocument(${
             doc.id
-        })" style="position: absolute; top: 12px; right: 12px; width: 32px; height: 32px;">
+        })" style="position: absolute; top: 12px; right: 12px; width: 32px; height: 32px;" aria-label="Delete document">
                 ${
             IconHelper.icon( IconHelper.getActionIcon( 'delete' ) )
         }

--- a/public/header.php
+++ b/public/header.php
@@ -371,7 +371,7 @@ $debugAssets = isset($_GET['debug']) && $_GET['debug'] === 'assets';
             <button class="btn-icon" onclick="showKeyboardShortcuts()" title="Keyboard Shortcuts" aria-label="Keyboard Shortcuts">
                 <?php echo IconHelper::icon('mdi:keyboard'); ?>
             </button>
-            <a href="https://github.com/<?php echo htmlspecialchars($githubUsername); ?>/<?php echo htmlspecialchars($githubRepo); ?>" target="_blank" class="btn-icon" title="View on GitHub" style="text-decoration: none; color: inherit;">
+            <a href="https://github.com/<?php echo htmlspecialchars($githubUsername); ?>/<?php echo htmlspecialchars($githubRepo); ?>" target="_blank" class="btn-icon" title="View on GitHub" aria-label="View on GitHub" style="text-decoration: none; color: inherit;">
                 <?php echo IconHelper::icon('mdi:github'); ?>
             </a>
         </div>


### PR DESCRIPTION
💡 **What**: Added descriptive `aria-label` attributes to several icon-only buttons across the frontend components.
🎯 **Why**: Icon-only buttons without `aria-label` attributes are inaccessible to screen readers. This micro-UX improvement ensures that visually impaired users or users relying on assistive technologies can understand the function of every button.
📸 **Before/After**: No visual change.
♿ **Accessibility**: Enhanced screen reader support by providing explicit text descriptions for icons (e.g., "Copy message", "Edit message", "Regenerate response", "View on GitHub", etc.).

---
*PR created automatically by Jules for task [15213372537809887789](https://jules.google.com/task/15213372537809887789) started by @LebToki*