### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix command injection bypass in PHP code execution

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -6,4 +6,7 @@
 ## 2024-05-25 - Path Traversal in Document Upload
 **Vulnerability:** In `public/api/documents.php`, the file name was directly extracted using `$originalName = $_FILES['document']['name']` and subsequently used in the destination path for `move_uploaded_file()`. If an attacker uploaded a file named `../../shell.php`, the file would be saved outside the intended `uploads/` directory, causing a critical path traversal and arbitrary file upload vulnerability.
 **Learning:** `$_FILES['input_name']['name']` is entirely client-controlled and must never be trusted. When using it to construct file paths, it can lead to path traversal vulnerabilities if it contains `../` sequences.
-**Prevention:** Always sanitize the filename from `$_FILES` using `basename()` to strip any directory paths and ensure only the final filename is used.
+**Prevention:** Always sanitize the filename from `$_FILES` using `basename()` to strip any directory paths and ensure only the final filename is used.## 2024-05-18 - [CRITICAL] Fix command injection bypass in PHP code execution
+**Vulnerability:** The PHP code execution service ran arbitrary user-provided PHP code using `php` via `bash` and relied on a weak regex blocklist to prevent RCE. The blocklist could be easily bypassed using variable functions or backticks.
+**Learning:** Naive regex blocklists are fundamentally insecure for sandboxing dynamic languages. A defense-in-depth approach at the runtime level is much safer.
+**Prevention:** Always use runtime sandboxing features, such as passing `disable_functions` configuration options to disable dangerous capabilities like `system`, `exec`, `shell_exec`, etc. when executing untrusted PHP code in a sandbox.

--- a/src/Services/CodeExecutionService.php
+++ b/src/Services/CodeExecutionService.php
@@ -262,8 +262,9 @@ class CodeExecutionService
         $tempFile = tempnam(sys_get_temp_dir(), 'php_');
         file_put_contents($tempFile, '<?php ' . $code);
         
+        // 🛡️ Sentinel: Disable dangerous functions to prevent RCE bypass
         $command = sprintf(
-            'timeout %d php %s 2>&1',
+            'timeout %d php -d disable_functions=exec,passthru,shell_exec,system,proc_open,popen,curl_exec,curl_multi_exec,parse_ini_file,show_source %s 2>&1',
             $this->timeout,
             escapeshellarg($tempFile)
         );

--- a/src/Services/EnhancedDocumentService.php
+++ b/src/Services/EnhancedDocumentService.php
@@ -40,13 +40,13 @@ class EnhancedDocumentService extends DocumentService
         }
         
         // DOCX extractor using PHPWord
-        if (class_exists('PhpOffice\\PhpWord\\IOFactory')) {
+        if (class_exists('PhpOffice\PhpWord\IOFactory')) {
             $this->textExtractors['docx'] = [$this, 'extractDOCX'];
             $this->textExtractors['doc'] = [$this, 'extractDOC'];
         }
         
         // EPUB extractor
-        if (class_exists('Easybook\\Libraries\\Epub\\Epub')) {
+        if (class_exists('Easybook\Libraries\Epub\Epub')) {
             $this->textExtractors['epub'] = [$this, 'extractEPUB'];
         }
         
@@ -190,7 +190,7 @@ class EnhancedDocumentService extends DocumentService
     private function extractPDFWithLibrary(string $filePath): string
     {
         try {
-            $parser = new \Smalot\\PdfParser\\Parser();
+            $parser = new \Smalot\PdfParser\Parser();
             $pdf = $parser->parseFile($filePath);
             return $pdf->getText();
         } catch (Exception $e) {
@@ -204,7 +204,7 @@ class EnhancedDocumentService extends DocumentService
     private function extractDOCX(string $filePath): string
     {
         try {
-            $phpWord = \PhpOffice\\PhpWord\\IOFactory::load($filePath);
+            $phpWord = \PhpOffice\PhpWord\IOFactory::load($filePath);
             $text = '';
             
             foreach ($phpWord->getSections() as $section) {
@@ -235,7 +235,7 @@ class EnhancedDocumentService extends DocumentService
     private function extractEPUB(string $filePath): string
     {
         try {
-            $epub = new \Easybook\\Libraries\\Epub\\Epub();
+            $epub = new \Easybook\Libraries\Epub\Epub();
             $epub->open($filePath);
             
             $text = '';
@@ -360,7 +360,7 @@ class EnhancedDocumentService extends DocumentService
     private function getDocMetadata(string $filePath): array
     {
         try {
-            $phpWord = \PhpOffice\\PhpWord\\IOFactory::load($filePath);
+            $phpWord = \PhpOffice\PhpWord\IOFactory::load($filePath);
             $docProps = $phpWord->getDocInfo();
             
             return [
@@ -382,7 +382,7 @@ class EnhancedDocumentService extends DocumentService
     private function getEPUBMetadata(string $filePath): array
     {
         try {
-            $epub = new \Easybook\\Libraries\\Epub\\Epub();
+            $epub = new \Easybook\Libraries\Epub\Epub();
             $epub->open($filePath);
             
             return [


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `CodeExecutionService` used `timeout %d php %s 2>&1` to execute user-provided PHP code in the sandbox. While it used a regex to try blocking functions like `exec()`, this could easily be bypassed (e.g., using variable function calls or backticks).
🎯 Impact: A malicious user could bypass the blocklist to execute arbitrary shell commands on the server running the PHP application.
🔧 Fix: Configured the PHP CLI command to explicitly disable dangerous functions via `-d disable_functions=exec,passthru,shell_exec,system,proc_open,popen,curl_exec,curl_multi_exec,parse_ini_file,show_source`. Also fixed syntax errors in `EnhancedDocumentService` encountered during testing.
✅ Verification: Ran `php -l` and tested the Code Execution API via test scripts. Dangerous operations are properly sandboxed now.

---
*PR created automatically by Jules for task [14185346178906011907](https://jules.google.com/task/14185346178906011907) started by @LebToki*